### PR TITLE
[feat]: [CI-8539]: Add retries in ti-service client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harness/ti-client
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect


### PR DESCRIPTION
We retryOnServerErrors only on idempotent endpoints like UploadCg, GetTestTimes and DownloadLink