### PR TITLE
[feat]: [CI-12837]: Add build cache metadata

### DIFF
--- a/types/cache/buildcache/types.go
+++ b/types/cache/buildcache/types.go
@@ -2,7 +2,7 @@ package buildcache
 
 type (
 	Metadata struct {
-		TotalTasks int `json:"total_tasks"`
-		Cached     int `json:"cached"`
+		TotalTasks  int `json:"total_tasks"`
+		CachedTasks int `json:"cached_tasks"`
 	}
 )

--- a/types/cache/buildcache/types.go
+++ b/types/cache/buildcache/types.go
@@ -1,0 +1,8 @@
+package buildcache
+
+type (
+	Metadata struct {
+		TotalTasks int `json:"total_tasks"`
+		Cached     int `json:"cached"`
+	}
+)

--- a/types/savings.go
+++ b/types/savings.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"github.com/harness/ti-client/types/cache/buildcache"
 	"github.com/harness/ti-client/types/cache/dlc"
 	"github.com/harness/ti-client/types/cache/gradle"
 )
@@ -24,6 +25,7 @@ const (
 type SavingsRequest struct {
 	GradleMetrics gradle.Metrics `json:"gradle_metrics"`
 	DlcMetrics    dlc.Metrics    `json:"dlc_metrics"`
+	Metadata      string         `json:"metadata"`
 }
 
 type SavingsOverview struct {
@@ -36,6 +38,7 @@ type SavingsOverview struct {
 
 // This Structure will have the savings overview for each step and also detailed metrics in the future such as dlc metrics and gradle metrics
 type SavingsResponse struct {
-	Overview    []SavingsOverview `json:"overview"` // array of SavingsOverview since one step can have multiple savings features enabled
-	DlcMetadata *dlc.Metadata     `json:"dlc_metadata"`
+	Overview           []SavingsOverview    `json:"overview"` // array of SavingsOverview since one step can have multiple savings features enabled
+	DlcMetadata        *dlc.Metadata        `json:"dlc_metadata"`
+	BuildCacheMetadata *buildcache.Metadata `json:"build_cache_metadata"`
 }

--- a/types/savings.go
+++ b/types/savings.go
@@ -25,7 +25,6 @@ const (
 type SavingsRequest struct {
 	GradleMetrics gradle.Metrics `json:"gradle_metrics"`
 	DlcMetrics    dlc.Metrics    `json:"dlc_metrics"`
-	Metadata      string         `json:"metadata"`
 }
 
 type SavingsOverview struct {


### PR DESCRIPTION
In this PR we add a new field to the API response of GetSavings. This is to show the build cache metadata if it exists

Tested on devspaces and with ti-service UTs.

Example API Response
<img width="1761" alt="Screenshot 2024-07-08 at 1 22 55 PM" src="https://github.com/harness/ti-client/assets/114451080/a11b52d5-c124-4c86-b18f-860c9c5abd3a">
